### PR TITLE
Prevent the karmaClean task from deleting all folders under node_modules

### DIFF
--- a/src/main/groovy/com/craigburke/gradle/KarmaPlugin.groovy
+++ b/src/main/groovy/com/craigburke/gradle/KarmaPlugin.groovy
@@ -95,7 +95,7 @@ class KarmaPlugin implements Plugin<Project> {
             doLast {
                 KARMA_CONFIG.delete()
                 project.file(NPM_OUTPUT_PATH).listFiles().each { File file ->
-                    if (file.isDirectory() && it.name.startsWith('karma')) {
+                    if (file.isDirectory() && file.name.startsWith('karma')) {
                         file.deleteDir()
                     }
                 }


### PR DESCRIPTION
This commit prevents the karmaClean task from deleting all folder under node_modules.
Instead, it will delete only the ones that begin with "karma", which was the original intention in the first place.